### PR TITLE
Fix homodimer panic by sharing one coarse-graining (gh #35)

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -149,6 +149,7 @@ fn load_from_structure(mol_path: &Path, cg_opts: &CgOptions) -> Result<LoadedMol
 }
 
 /// Result of in-memory molecule loading (no file paths).
+#[derive(Clone)]
 pub struct LoadedMoleculeInMemory {
     pub structure: Structure,
     pub topology: Topology,

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,22 @@ fn do_scan(cmd: &Commands) -> Result<()> {
 
     let cg_opts = cg_options_from_args(*ph, model, cg, scale_hydrophobic, chain);
     let loaded_a = loader::load_molecule(mol1, top_file.as_deref(), &cg_opts)?;
-    let loaded_b = loader::load_molecule(mol2, top_file.as_deref(), &cg_opts)?;
+
+    let homo_dimer = mol1 == mol2;
+    if homo_dimer {
+        info!("Homo-dimer detected (same input files); reusing single coarse-graining");
+    }
+
+    // Reuse A's structure for B in a homodimer so both bodies share one titration
+    // outcome. With --cg multi the titration is stochastic, so a second independent
+    // coarse-graining can disagree on atom-type counts and overflow the pair table
+    // (gh #35). This also halves the coarse-graining work.
+    let ref_b = if homo_dimer {
+        loaded_a.structure.clone()
+    } else {
+        loader::load_molecule(mol2, top_file.as_deref(), &cg_opts)?.structure
+    };
+
     let top_path = &loaded_a.topology_path;
     let topology = loaded_a.topology;
 
@@ -430,7 +445,6 @@ fn do_scan(cmd: &Commands) -> Result<()> {
     let nonbonded = NonbondedMatrix::from_file(top_path, &topology, Some(medium.clone()))?;
 
     let ref_a = loaded_a.structure;
-    let ref_b = loaded_b.structure;
 
     info!("{medium}");
     info!(
@@ -467,11 +481,6 @@ fn do_scan(cmd: &Commands) -> Result<()> {
         }
         other => *other,
     };
-
-    let homo_dimer = mol1 == mol2;
-    if homo_dimer {
-        info!("Homo-dimer detected (same input files)");
-    }
 
     let scan_config = icoscan::ScanConfig {
         params: icoscan::ScanParams {

--- a/src/web_api.rs
+++ b/src/web_api.rs
@@ -71,8 +71,18 @@ fn prepare_scan(req: &WebScanRequest) -> anyhow::Result<PreparedScan> {
 
     log::info!("Coarse-graining molecule 1...");
     let mol1 = load_molecule_from_pdb_bytes(&req.mol1_pdb, &cg_opts)?;
-    log::info!("Coarse-graining molecule 2...");
-    let mol2 = load_molecule_from_pdb_bytes(&req.mol2_pdb, &cg_opts)?;
+
+    // Reuse molecule 1 for a homodimer so both bodies share one titration outcome.
+    // With multi-bead CG the titration is stochastic, so a second independent
+    // coarse-graining can disagree on atom-type counts and overflow the pair table
+    // (gh #35).
+    let mol2 = if req.homo_dimer {
+        log::info!("Homo-dimer: reusing molecule 1 coarse-graining for molecule 2");
+        mol1.clone()
+    } else {
+        log::info!("Coarse-graining molecule 2...");
+        load_molecule_from_pdb_bytes(&req.mol2_pdb, &cg_opts)?
+    };
 
     let medium = Medium::salt_water(req.temperature, Salt::SodiumChloride, req.molarity);
 


### PR DESCRIPTION
A homodimer coarse-grained the same input twice independently. With --cg multi the titration is stochastic, so the two runs could disagree on atom-type counts; molecule B's atom_ids then overran the pair table built from A's topology, panicking in the SIMD backend.

Coarse-grain once and reuse the structure for both bodies. Same fix in the web API, gated on its homo_dimer flag.

Fixes #35 