### PR TITLE
Unify atom-kind namespace for hetero-dimer scans (gh #35)

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -14,7 +14,7 @@
 
 use crate::structure::Structure;
 use anyhow::{Context, Result};
-use faunus::topology::{self, Topology};
+use faunus::topology::{self, AtomKind, Topology};
 use std::io::{BufReader, Cursor};
 use std::path::{Path, PathBuf};
 
@@ -203,4 +203,117 @@ pub fn load_molecule_from_pdb_bytes(
         topology,
         topology_yaml,
     })
+}
+
+/// Resolve molecule B's backend structure and the atom-kind namespace shared by both
+/// bodies of a scan.
+///
+/// `molecule_b = None` is a homodimer: reuse A's structure and topology, i.e. a single
+/// coarse-graining (gh #35). Otherwise the two molecules were coarse-grained independently
+/// into separate id spaces, so their topologies are combined and B's structure ids are
+/// remapped into the shared table.
+pub fn prepare_pair(
+    topology_a: &Topology,
+    structure_a: &Structure,
+    molecule_b: Option<(&Topology, &Structure)>,
+) -> (Structure, Topology) {
+    let Some((topology_b, structure_b)) = molecule_b else {
+        return (structure_a.clone(), topology_a.clone());
+    };
+    let (merged, b_remap) = combine_topologies(topology_a, topology_b);
+    let mut structure_b = structure_b.clone();
+    structure_b.remap_atom_ids(&b_remap);
+    (structure_b, merged)
+}
+
+/// Merge molecule B's atom kinds into A's, returning the combined topology and a
+/// map from B's old atom-kind id to its id in the merged table.
+///
+/// Kinds with identical force-field parameters share an id — keeping the type count, and
+/// hence the n_types² spline table, small — while the rest are appended. Names may then
+/// repeat across molecules (e.g. titratable sites at different charges), which is harmless:
+/// energy is keyed by id, not name, and pair potentials come from arithmetic mixing of
+/// each kind's charge/σ/ε.
+fn combine_topologies(topology_a: &Topology, topology_b: &Topology) -> (Topology, Vec<usize>) {
+    let mut merged = topology_a.clone();
+    let mut b_remap = Vec::with_capacity(topology_b.atomkinds().len());
+
+    for kind_b in topology_b.atomkinds() {
+        let merged_id = merged
+            .atomkinds()
+            .iter()
+            .position(|kind| same_interaction(kind, kind_b))
+            .unwrap_or_else(|| {
+                let id = merged.atomkinds().len();
+                merged.add_atomkind(kind_b.clone());
+                id
+            });
+        b_remap.push(merged_id);
+    }
+
+    // Re-index the combined table (skipping `finalize_atoms`, which rejects the
+    // duplicate names that legitimately arise here).
+    for (id, kind) in merged.atomkinds_mut().iter_mut().enumerate() {
+        kind.set_id(id);
+    }
+
+    (merged, b_remap)
+}
+
+/// True if two atom kinds are interchangeable for energy: identical charge and
+/// short-range parameters. Names are ignored (they don't enter pair-potential mixing).
+fn same_interaction(a: &AtomKind, b: &AtomKind) -> bool {
+    let opt_bits = |x: Option<f64>| x.map(f64::to_bits);
+    a.charge().to_bits() == b.charge().to_bits()
+        && a.mass().to_bits() == b.mass().to_bits()
+        && opt_bits(a.sigma()) == opt_bits(b.sigma())
+        && opt_bits(a.epsilon()) == opt_bits(b.epsilon())
+        && opt_bits(a.lambda()) == opt_bits(b.lambda())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finalized(yaml: &str) -> Topology {
+        let mut top = Topology::from_str_partial(yaml).unwrap();
+        top.finalize_atoms().unwrap();
+        top
+    }
+
+    #[test]
+    fn combine_topologies_dedups_shared_and_appends_distinct() {
+        // GLY is identical in both; O1 differs only in charge (a titratable site).
+        let top_a = finalized(
+            "atoms:\n  - {name: GLY, mass: 57.0, charge: 0.0, σ: 4.5, ε: 0.83}\n  \
+             - {name: O1, mass: 0.0, charge: -0.9, σ: 2.0, ε: 0.83}\n",
+        );
+        let top_b = finalized(
+            "atoms:\n  - {name: GLY, mass: 57.0, charge: 0.0, σ: 4.5, ε: 0.83}\n  \
+             - {name: O1, mass: 0.0, charge: -0.4, σ: 2.0, ε: 0.83}\n",
+        );
+
+        let (merged, b_remap) = combine_topologies(&top_a, &top_b);
+
+        // GLY shared, B's O1 appended → 3 kinds with contiguous ids.
+        assert_eq!(merged.atomkinds().len(), 3);
+        for (i, kind) in merged.atomkinds().iter().enumerate() {
+            assert_eq!(kind.id(), i);
+        }
+        // B's GLY folds onto A's id 0; B's distinct O1 lands at the new id 2.
+        assert_eq!(b_remap, vec![0, 2]);
+        // The appended kind keeps B's own charge.
+        assert_eq!(merged.atomkinds()[2].charge().to_bits(), (-0.4f64).to_bits());
+    }
+
+    #[test]
+    fn combine_identical_topologies_is_a_noop() {
+        let top = finalized(
+            "atoms:\n  - {name: GLY, mass: 57.0, charge: 0.0, σ: 4.5, ε: 0.83}\n  \
+             - {name: ASP, mass: 115.0, charge: -1.0, σ: 5.6, ε: 0.83}\n",
+        );
+        let (merged, b_remap) = combine_topologies(&top, &top);
+        assert_eq!(merged.atomkinds().len(), 2);
+        assert_eq!(b_remap, vec![0, 1]);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,18 +417,21 @@ fn do_scan(cmd: &Commands) -> Result<()> {
         info!("Homo-dimer detected (same input files); reusing single coarse-graining");
     }
 
-    // Reuse A's structure for B in a homodimer so both bodies share one titration
-    // outcome. With --cg multi the titration is stochastic, so a second independent
-    // coarse-graining can disagree on atom-type counts and overflow the pair table
-    // (gh #35). This also halves the coarse-graining work.
-    let ref_b = if homo_dimer {
-        loaded_a.structure.clone()
+    // Resolve molecule B and the atom-kind namespace shared by both bodies (gh #35): a
+    // homodimer reuses A's single coarse-graining; a hetero-dimer is coarse-grained
+    // independently, so its ids are remapped into a table combined from both molecules.
+    let loaded_b = if homo_dimer {
+        None
     } else {
-        loader::load_molecule(mol2, top_file.as_deref(), &cg_opts)?.structure
+        Some(loader::load_molecule(mol2, top_file.as_deref(), &cg_opts)?)
     };
+    let (ref_b, topology) = loader::prepare_pair(
+        &loaded_a.topology,
+        &loaded_a.structure,
+        loaded_b.as_ref().map(|b| (&b.topology, &b.structure)),
+    );
 
     let top_path = &loaded_a.topology_path;
-    let topology = loaded_a.topology;
 
     // Either use fixed dielectric constant or calculate it from the medium
     let medium = fixed_dielectric.map_or_else(

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -91,6 +91,12 @@ impl Structure {
         Ok(structure)
     }
 
+    /// Remap atom-kind ids through `map` (old id → merged id) after this molecule's
+    /// kinds were folded into a shared namespace (gh #35). See `loader::combine_topologies`.
+    pub fn remap_atom_ids(&mut self, map: &[usize]) {
+        self.atom_ids.iter_mut().for_each(|id| *id = map[*id]);
+    }
+
     /// Constructs a new structure from an XYZ file, centering the structure at the origin
     pub fn from_xyz(path: &PathBuf, atomkinds: &[AtomKind]) -> Result<Self> {
         let content = std::fs::read_to_string(path)

--- a/src/web_api.rs
+++ b/src/web_api.rs
@@ -10,8 +10,11 @@ use crate::energy::{CoulombParams, PairMatrix, SplinedPotentials};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::icoscan::compute_scan;
 use crate::icoscan::{compute_scan_async, ScanParams};
-use crate::loader::{load_molecule_from_pdb_bytes, CgOptions, LoadedMoleculeInMemory};
+use crate::loader::{
+    load_molecule_from_pdb_bytes, prepare_pair, CgOptions, LoadedMoleculeInMemory,
+};
 use crate::report::compute_pmf;
+use crate::structure::Structure;
 use crate::VirialCoeff;
 use faunus::energy::NonbondedMatrix;
 use faunus::interatomic::coulomb::{DebyeLength as _, Medium, Salt};
@@ -58,6 +61,10 @@ struct PreparedScan {
     coulomb: CoulombParams,
     mol1: LoadedMoleculeInMemory,
     mol2: LoadedMoleculeInMemory,
+    /// Molecule B's structure with atom-kind ids remapped into the shared namespace
+    /// used by the energy table (gh #35). Equals `mol1.structure` for a homodimer.
+    /// `mol1`/`mol2` keep their original ids for display/XYZ output.
+    backend_ref_b: Structure,
     medium: Medium,
 }
 
@@ -84,12 +91,18 @@ fn prepare_scan(req: &WebScanRequest) -> anyhow::Result<PreparedScan> {
         load_molecule_from_pdb_bytes(&req.mol2_pdb, &cg_opts)?
     };
 
+    // Build the energy table over a namespace shared by both molecules (gh #35): a
+    // hetero-dimer is coarse-grained independently, so molecule 2's ids are remapped into a
+    // combined table; a homodimer already shares molecule 1's namespace.
+    let molecule_b = (!req.homo_dimer).then_some((&mol2.topology, &mol2.structure));
+    let (backend_ref_b, topology) = prepare_pair(&mol1.topology, &mol1.structure, molecule_b);
+
     let medium = Medium::salt_water(req.temperature, Salt::SodiumChloride, req.molarity);
 
     let nonbonded =
-        NonbondedMatrix::from_str(&mol1.topology_yaml, &mol1.topology, Some(medium.clone()))?;
+        NonbondedMatrix::from_str(&mol1.topology_yaml, &topology, Some(medium.clone()))?;
 
-    let pair_matrix = PairMatrix::new(nonbonded, mol1.topology.atomkinds(), &medium);
+    let pair_matrix = PairMatrix::new(nonbonded, topology.atomkinds(), &medium);
 
     let spline_config = SplineConfig {
         n_points: req.grid_size,
@@ -105,6 +118,7 @@ fn prepare_scan(req: &WebScanRequest) -> anyhow::Result<PreparedScan> {
         coulomb,
         mol1,
         mol2,
+        backend_ref_b,
         medium,
     })
 }
@@ -184,7 +198,7 @@ pub async fn run_scan_async(
     log::info!("Initializing GPU backend...");
     let backend = GpuBackend::new_async(
         prep.mol1.structure.clone(),
-        prep.mol2.structure.clone(),
+        prep.backend_ref_b.clone(),
         &prep.sr_splines,
         &prep.coulomb,
     )
@@ -209,7 +223,7 @@ pub fn run_scan(req: WebScanRequest) -> anyhow::Result<WebScanResult> {
     log::info!("Initializing GPU backend...");
     let backend = GpuBackend::new(
         prep.mol1.structure.clone(),
-        prep.mol2.structure.clone(),
+        prep.backend_ref_b.clone(),
         &prep.sr_splines,
         &prep.coulomb,
     )?;


### PR DESCRIPTION
Each molecule is coarse-grained into its own atom-kind id space, but the energy matrix was built from molecule A's topology alone, so molecule B's ids indexed it wrongly — out-of-bounds panic or silent mis-parametrisation.

Combine both topologies into one shared table (deduping identical kinds to keep the n_types^2 spline table small) and remap B's structure ids into it. A new prepare_pair helper drives this for both the CLI and web API; the homodimer path still reuses A's single coarse-graining.